### PR TITLE
Remove Python 2-related universal wheel config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal=1
-
 [tool:pytest]
 addopts = tests/


### PR DESCRIPTION
Universal wheels were designed to identify pure-Python wheels that support both Python 2 and Python 3.

Since this project supports only Python 3.8+ setting this is no longer appropriate.